### PR TITLE
Missing components for make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: build
 check: fmt build test
 
 build:
-	CGO_ENABLED=$(CGO_ENABLED) $(GO) build -ldflags $(BUILDFLAGS) -o bin/$(NAME) $(MAIN_GO)
+	CGO_ENABLED=$(CGO_ENABLED) $(GO) build -ldflags $(BUILDFLAGS) -o bin/$(NAME) $(MAIN_GO) $(COMPONENTS)
 
 test: 
 	CGO_ENABLED=$(CGO_ENABLED) $(GO) test $(PACKAGE_DIRS) -test.v


### PR DESCRIPTION
make build didn't include types.go and player.go. Other make targets may be affected.